### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/packages/collection-diff-apply/index.js
+++ b/packages/collection-diff-apply/index.js
@@ -80,6 +80,9 @@ function diffApply(obj, diff, pathConverter) {
     }
     var thisProp;
     while (((thisProp = pathCopy.shift())) != null) {
+      if (thisProp === '__proto__' || thisProp === 'constructor' || thisProp === 'prototype') {
+        throw new Error('Prototype pollution attempt detected');
+      }
       if (!(thisProp in subObject)) {
         subObject[thisProp] = {};
       }

--- a/packages/object-safe-set/index.js
+++ b/packages/object-safe-set/index.js
@@ -36,6 +36,9 @@ function set(obj, props, value) {
   }
   var thisProp;
   while ((thisProp = props.shift())) {
+    if (thisProp === '__proto__' || thisProp === 'constructor' || thisProp === 'prototype') {
+      return false;
+    }
     if (typeof obj[thisProp] == 'undefined') {
       obj[thisProp] = {};
     }


### PR DESCRIPTION
### 📊 Metadata *

`just-diff-apply` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL: 
https://www.huntr.dev/bounties/1-npm-just-diff-apply/
https://www.huntr.dev/bounties/1-npm-just-safe-set/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Clone repository https://github.com/angus-c/just

2. Create the following PoC file at downloaded dir:

```js
// poc.js
var {diffApply} = require("./packages/collection-diff-apply/")
var obj = {}
const patch = [{op: "add", path: ["__proto__","polluted"], value: "Yes! Its Polluted"}];
console.log("Before : " + obj.polluted);
diffApply(obj, patch);
var obj1={}
console.log("After : " + obj1.polluted);
```

2. Execute the following commands in another terminal:

```bash
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

After fix execution will block prototype pollution and throw an exception 

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected